### PR TITLE
Add docs on Unsloth RL and OpenPipe Ruler

### DIFF
--- a/docs/evaluation/ruler.md
+++ b/docs/evaluation/ruler.md
@@ -1,0 +1,39 @@
+---
+Title: OpenPipe Ruler
+Summary: Rule-based tests for validating LLM outputs.
+Tags: [evaluation, openpipe, testing]
+Updated: 2025-09-01
+Links:
+  - label: Ruler Docs
+    url: https://art.openpipe.ai/fundamentals/ruler
+---
+
+# OpenPipe Ruler
+
+Ruler provides a lightweight syntax to express expectations for model responses.
+It lets teams encode guards like required phrases, regex patterns, or score thresholds and run them as unit tests.
+
+## Key Points
+- Define rules in YAML or Python for reuse across prompts.
+- Run checks locally or in CI to catch regressions early.
+- Supports custom evaluators for domain-specific metrics.
+
+## Minimal Example
+```python
+from openpipe.ruler import Rule, evaluate
+
+rules = [
+    Rule.must_contain("bonjour"),
+    Rule.max_tokens(50),
+]
+
+result = evaluate(prompt="Translate to French: hello", rules=rules)
+print(result.passed)
+```
+
+## Notes
+- Combine with RAG or fine-tuned models to enforce policy constraints.
+- Failing tests surface diffs between expected and actual outputs.
+
+## Further Reading
+- [Ruler Docs](https://art.openpipe.ai/fundamentals/ruler) — official guide.

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -16,6 +16,8 @@ Curated references for deeper study and practical use.
 - LangChain: https://python.langchain.com
 - LlamaIndex: https://gpt-index.readthedocs.io
 - OpenTelemetry: https://opentelemetry.io
+- Unsloth RL Guide: https://docs.unsloth.ai/basics/reinforcement-learning-rl-guide/training-ai-agents-with-rl
+- OpenPipe Ruler: https://art.openpipe.ai/fundamentals/ruler
 
 ## Learning
 - The Batch (deeplearning.ai): https://www.deeplearning.ai/the-batch/

--- a/docs/training/unsloth-rl.md
+++ b/docs/training/unsloth-rl.md
@@ -1,0 +1,47 @@
+---
+Title: Unsloth RL Training
+Summary: Basic workflow for reinforcing LLMs with Unsloth.
+Tags: [training, rl, unsloth]
+Updated: 2025-09-01
+Links:
+  - label: Unsloth RL Guide
+    url: https://docs.unsloth.ai/basics/reinforcement-learning-rl-guide/training-ai-agents-with-rl
+---
+
+# Unsloth RL Training
+
+Unsloth offers a lightweight interface for reinforcement learning on top of popular Llama-class models.
+It focuses on efficient PPO-style fine-tuning where an agent learns from reward signals rather than fixed outputs.
+
+## Key Points
+- Wrap a base model with `FastLanguageModel` and provide a reward function.
+- Use proximal policy optimization (PPO) steps to update the policy.
+- Log metrics such as reward, KL divergence, and token usage for debugging.
+
+## Minimal Example
+```python
+from unsloth import FastLanguageModel
+from unsloth.ppo import PPOTrainer, RLConfig
+
+# load a quantized base model
+model, tokenizer = FastLanguageModel.from_pretrained(
+    model_name="meta-llama/Llama-3-8b",
+    load_in_4bit=True,
+)
+
+config = RLConfig(batch_size=4, lr=1e-5, ppo_epochs=1)
+trainer = PPOTrainer(model, tokenizer, config)
+
+prompt = "Translate to French: Hello world"
+outputs = trainer.generate(prompt)
+reward = some_reward_fn(prompt, outputs)
+trainer.step(prompt, outputs, reward)
+```
+
+## Notes
+- Reward models can be learned or heuristic.
+- Training often alternates between supervised fine-tuning and RL steps.
+- Monitor stability; clip KL to prevent divergence.
+
+## Further Reading
+- [Unsloth RL Guide](https://docs.unsloth.ai/basics/reinforcement-learning-rl-guide/training-ai-agents-with-rl) — official walkthrough.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,9 +47,11 @@ nav:
       - Training: training/overview.md
       - Training / Swift (ms-swift): training/ms-swift.md
       - Training / Unsloth: training/unsloth.md
+      - Training / Unsloth RL: training/unsloth-rl.md
       - Inference: inference/overview.md
       - Evaluation: evaluation/overview.md
       - Evaluation / EvalScope: evaluation/evalscope.md
+      - Evaluation / Ruler: evaluation/ruler.md
       - Datasets: datasets/overview.md
       - Datasets / easy-dataset: datasets/easy-dataset.md
       - Alignment & Safety: alignment-safety/overview.md


### PR DESCRIPTION
## Summary
- document Unsloth-based PPO training workflow
- add page for OpenPipe's Ruler rule-based evaluation
- include links in resources and navigation

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b50a7fe6f883289c9b48fb4bdd4bca