### PR TITLE
docs: add wiki URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A community-friendly wiki for Large Language Model (LLM) knowledge: foundations, prompting, training, inference, evaluation, safety, agents, infrastructure, and applied patterns. Organized for quick lookup and steady growth.
 
+**Read the wiki online:** https://tiancai19.github.io/llm-cody-wiki/
+
 ## Quick Start
 - Browse content in `docs/` directly.
 - Optional site (MkDocs):


### PR DESCRIPTION
## Summary
- link to the published LLM Cody wiki in the README for easy access

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68b51ea921f083288e104c17cd3f9e0e